### PR TITLE
Integrate jekyll-last-modified-at plugin to add last updated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ group :jekyll_plugins do
   gem 'jekyll-asciidoc'
   gem 'jekyll-paginate'
   gem 'jekyll-tagging'
+  gem 'jekyll-last-modified-at'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,8 +14,8 @@ GEM
     eventmachine (1.2.7)
     extras (0.3.0)
       forwardable-extended (~> 2.5)
-    fastimage (2.2.1)
-    ffi (1.14.2)
+    fastimage (2.2.3)
+    ffi (1.15.0)
     forwardable-extended (2.6.0)
     html-proofer (3.18.5)
       addressable (~> 2.3)
@@ -54,6 +54,9 @@ GEM
       sprockets (~> 3.3, < 3.8)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-last-modified-at (1.3.0)
+      jekyll (>= 3.7, < 5.0)
+      posix-spawn (~> 0.3.9)
     jekyll-paginate (1.1.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
@@ -82,6 +85,7 @@ GEM
     parallel (1.20.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    posix-spawn (0.3.15)
     public_suffix (4.0.6)
     racc (1.5.2)
     rack (1.6.13)
@@ -116,6 +120,7 @@ DEPENDENCIES
   jekyll-asciidoc
   jekyll-assets (= 2.3.2)
   jekyll-include-cache
+  jekyll-last-modified-at
   jekyll-paginate
   jekyll-redirect-from
   jekyll-tagging

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,10 @@ plugins:
   - jekyll-assets
   - jekyll-include-cache
   - jekyll-asciidoc
+  - jekyll-last-modified-at
+
+last-modified-at:
+  date-format: '%F'
 
 page_gen:
   - index_files: true

--- a/_source/_assets/css/okta/components/_BlogPost.scss
+++ b/_source/_assets/css/okta/components/_BlogPost.scss
@@ -78,6 +78,11 @@
 		line-height: 24px;
 	}
 
+	&-last-updated {
+		float: right;
+		border: 1px solid red;
+	}
+
 	&-author-bio {
 		@include color('charcoal');
 		border-top: 1px #ccc solid;

--- a/_source/_includes/blog_post.html
+++ b/_source/_includes/blog_post.html
@@ -13,7 +13,9 @@
             {{ post.title }}
             {% endif %}
         </h1>
-
+        <div class="BlogPost-last-updated">
+            Last Updated: {% last_modified_at %}
+        </div>
         <div class="BlogPost-attribution">
             {% if author.avatar %}
             <a href="/blog/authors/{{ post.author }}/">{% img '{{ author.avatar }}' alt:'{{ author.avatar }}' class:BlogPost-avatar %}</a>


### PR DESCRIPTION
Fixes #595. Or rather, it would if it worked. Steps to reproduce issues:

```
git clone -b last-modified git@github.com:oktadeveloper/okta-blog.git 
bundle install
npm i
npm start
```

The error I'm getting is:

```
> @oktadeveloper/okta-blog@1.0.0 start
> bundle exec jekyll serve --future --livereload --host=0.0.0.0

Configuration file: /Users/mraible/dev/okta/okta-blog/_config.yml
            Source: _source
       Destination: dist
 Incremental build: disabled. Enable with --incremental
      Generating... 
  Liquid Exception: No such file or directory - /Users/mraible/dev/okta/okta-blog/_source/blog/tags/android/index.html does not exist! in /_layouts/tag.html
jekyll 3.9.0 | Error:  No such file or directory - /Users/mraible/dev/okta/okta-blog/_source/blog/tags/android/index.html does not exist!
```

I [added a comment](https://github.com/gjtorikian/jekyll-last-modified-at/issues/24#issuecomment-795051937) to the source repo. FWIW, the jekyll-last-modified-at project is [looking for maintainers](https://github.com/gjtorikian/jekyll-last-modified-at/issues/79), so it might not be the best implementation to use.
