### PR TITLE
Add Java tags to recent posts

### DIFF
--- a/_source/_posts/2021-07-12-spring-boot-test-slices.md
+++ b/_source/_posts/2021-07-12-spring-boot-test-slices.md
@@ -5,7 +5,7 @@ author: ruslan-zaharov
 by: contractor
 communities: [java]
 description: "Spring Boot Test Slices allow you to test a specific part of your application in isolation without loading the whole Spring context."
-tags: [spring, spring-boot, testing, spring-testing, unit-testing, integration-testing]
+tags: [spring, spring-boot, testing, spring-testing, unit-testing, integration-testing, java]
 tweets:
 - "Unit tests are the most valuable when they are stable, fast, and reproducible. Speed your @springboot tests up with the tips in this tutorial!"
 - "In this tutorial, you'll learn about Spring Boot testing capabilities to optimize integration tests."

--- a/_source/_posts/2021-07-30-spring-webclient.md
+++ b/_source/_posts/2021-07-30-spring-webclient.md
@@ -5,7 +5,7 @@ author: jimena-garbarino
 by: contractor
 communities: [java]
 description: "This tutorial shows how to integrate third-party secure resources with Spring WebClient."
-tags: [spring, spring-webclient, integration-testing, webtestclient, testing, oauth2, mockwebserver]
+tags: [spring, spring-webclient, java, integration-testing, webtestclient, testing, oauth2, mockwebserver]
 tweets:
 - "Spring ẀebClient was added as part of the reactive web stack WebFlux in Spring Framework 5.0. Learn more! 👇"
 - "Spring WebClient provides a slick API for connecting to OAuth-protected resources. 💪"


### PR DESCRIPTION
So they show up at https://developer.okta.com/blog/tags/java. 