### PR TITLE
Draft Add Netlify CMS (to draft new posts) and create pull requests

### DIFF
--- a/_source/admin/config.yml
+++ b/_source/admin/config.yml
@@ -1,0 +1,91 @@
+backend:
+  name: github
+  repo: oktadev/okta-blog
+  branch: main
+  auth_scope: repo # fork for external contrib
+  open_authoring: true
+publish_mode: editorial_workflow
+media_folder: '_source/_assets/img/blog/'
+public_folder: 'blog/'
+collections:
+  - name: 'blog'
+    label: 'Blog'
+    sort: "date:desc" # Default is title:asc
+    folder: '_source/_posts/'
+    create: true
+    slug: '{{year}}-{{month}}-{{day}}-{{slug}}'
+    identifier_field: title
+    # This doesn't map correctly, this value gets added to the 'folder'
+    media_folder: '/_source/_assets/img/blog/{{slug}}'
+    public_folder: 'blog/{{slug}}'
+    editor:
+      preview: false
+    fields:
+      - name: layout
+        label: Layout
+        widget: hidden
+        default: blog_post
+
+      - name: title
+        label: Title
+        widget: string
+
+      - name: author
+        label: Author
+        # TODO: This may need to be a list in the future?
+        widget: string
+
+      - name: date
+        label: 'Publish Date (Post filename may need to be adjusted in GitHub)'
+        widget: datetime
+
+      # copied from _source/_data/front-matter.json TODO: DRY this out
+      - name: communities
+        label: Communities
+        widget: select
+        multiple: true
+        options: [ ".net",
+                   "design",
+                   "gaming",
+                   "go",
+                   "java",
+                   "javascript",
+                   "mobile",
+                   "php",
+                   "python",
+                   "ruby",
+                   "security",
+                   "devops" ]
+
+      # copied from _source/_data/front-matter.json TODO: DRY this out
+      - name: by
+        label: By
+        widget: select
+        options: [ "advocate", "contractor", "internal-contributor", "external-contributor" ]
+
+      # copied from _source/_data/front-matter.json TODO: DRY this out
+      - name: type
+        label: Type
+        widget: select
+        options: [ "awareness", "conversion" ]
+
+      - name: tags
+        label: Tags
+        widget: list
+        min: 2
+
+      - name: tweets
+        label: Tweets
+        widget: array
+
+      - name: image
+        label: 'Social Image'
+        widget: image
+
+      - name: description
+        labl: Description
+        widget: text
+
+      - name: body
+        label: Body
+        widget: 'markdown'

--- a/_source/admin/index.html
+++ b/_source/admin/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Content Manager</title>
+</head>
+<body>
+<!-- Include the script that builds the page and powers Netlify CMS -->
+<script src="https://unpkg.com/netlify-cms@^2.10.153/dist/netlify-cms.js"></script>
+
+<script>
+    var ArrayControl = createClass({
+        handleChange: function (e) {
+            const separator = this.props.field.get("separator", ", ");
+            this.props.onChange(e.target.value.split(separator));
+        },
+
+        render: function () {
+            const separator = this.props.field.get("separator", ", ");
+            var value = this.props.value;
+            return h("input", {
+                id: this.props.forID,
+                className: this.props.classNameWrapper,
+                type: "text",
+                value: value ? value.join(separator) : "",
+                onChange: this.handleChange,
+            });
+        },
+    });
+
+    var ArrayPreview = createClass({
+        render: function () {
+            return h(
+                "ul",
+                {},
+                this.props.value.map(function (val, index) {
+                    return h("li", { key: index }, val);
+                })
+            );
+        },
+    });
+
+    var schema = {
+        properties: {
+            separator: { type: "string" },
+        },
+    };
+
+    CMS.registerWidget("array", ArrayControl, ArrayPreview, schema);
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Quick POC of adding the Netlify CMS to the blog, you should be able to browse the Netlify preview of this build and navigate to `/admin` manually (**NOTE**, replace the `/blog` with `/admin` in the URL)

Example Pull Request: #851

There are a couple of big gotchas:
- images uploaded got to the wrong directory [blocker], but this might be something we could tweak
- image tags use markdown and not liquid tags
- URL slugs are resolved from the title of the post
- Netlify CMS does not parse filename dates from Jekyll posts (there is a workaround but it would take a bit of work)

That said, it's still promising 🤔, GitHub PRs are created automatically, all the post metadata can be selected from dropdowns.
