### PR TITLE
Set default code block tab size to 4 spaces

### DIFF
--- a/_source/_assets/css/_code.scss
+++ b/_source/_assets/css/_code.scss
@@ -71,3 +71,4 @@
 .highlight .gt { color: #333333; background-color: #f0f0f0; } /* Generic Traceback */
 .highlight .x { color: #333333; background-color: #f0f0f0; } /* Other */
 .highlight .w { color: #333333; background-color: #f0f0f0; } /* Text Whitespace */
+pre.highlight { tab-size: 4; } /* 4 spaces for tabs */


### PR DESCRIPTION
This blog post has the following features:

- [ ] A GitHub Repository with a polished README
- [ ] A GitHub Repository under the github.com/oktadev account
- [ ] A title that's approved by Dev Advocacy
- [ ] A URL that's approved by Dev Advocacy
- [ ] The content has been ran through Grammarly (https://www.grammarly.com/)
- [ ] Rendered locally and confirmed that no Markdown typos exist
