### PR TITLE
Update asciidoc overflow-x to auto

### DIFF
--- a/_source/_assets/css/asciidoctor.css
+++ b/_source/_assets/css/asciidoctor.css
@@ -365,7 +365,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 /* New rules added by mraible */
 .paragraph > p, .sectionbody .ulist, .admonitionblock, .quoteblock blockquote p:last-child, .olist, .ulist, details, details > summary.title {
     margin: 20px 0;
-    overflow-x: scroll;
+    overflow-x: auto;
 }
 
 .scrollable {


### PR DESCRIPTION
It looks `scroll` is adding scroll bars on other sections/paragraphs, changing this to `auto` hides them by default, and only displays the scrollbar as needed
