### PR TITLE
Add web url for my profile

### DIFF
--- a/_source/_data/authors.yml
+++ b/_source/_data/authors.yml
@@ -531,6 +531,7 @@ giorgi-dalakishvili:
   github: https://github.com/Giorgi/
   twitter: https://twitter.com/GioDalakishvili
   linkedin: https://www.linkedin.com/in/giorgidalakishvili/
+  web: https://giorgi.dev
 
 nick-gamb:
   full_name: Nick Gamb


### PR DESCRIPTION
Many authors have website url listed under their profile so I added it to my profile as well.

This blog post has the following features:

- [ ] A GitHub Repository with a polished README
- [ ] A GitHub Repository under the github.com/oktadev account
- [ ] A title that's approved by Dev Advocacy
- [ ] A URL that's approved by Dev Advocacy
- [ ] The content has been run through Grammarly (https://www.grammarly.com/)
- [ ] Rendered locally and confirmed that no Markdown typos exist
