### PR TITLE
update action

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -17,7 +17,7 @@ jobs:
       run: npm install
 
     - name: Set up ruby and bundler
-      uses: actions/setup-ruby@v1.1.3
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6
 


### PR DESCRIPTION
Changing ruby action to `ruby/setup-ruby`. The `action/setup-ruby` action is no longer maintained
