### PR TITLE
mvp enterprise readiness/maturity distinction

### DIFF
--- a/_source/_posts/2023-07-27-enterprise-ready-getting-started.md
+++ b/_source/_posts/2023-07-27-enterprise-ready-getting-started.md
@@ -1,6 +1,6 @@
 ---
 layout: blog_post
-title: "How to Get Going with the Enterprise-Ready SaaS Apps Workshops"
+title: "How to Get Going with the On-Demand SaaS Apps Workshops"
 author: alisa-duncan
 by: advocate
 communities: [devops,security,.net,java,javascript,php,python]
@@ -11,7 +11,7 @@ type: awareness
 github: https://github.com/oktadev/okta-enterprise-ready-workshops
 ---
 
-Having an enterprise-ready SaaS application means your application supports authentication best practices, can scale across multiple customers and users, has automated means to re-create environments, and can securely add enhancements and value-adds your customers expect. Join this free virtual workshop series where we take your SaaS application on a journey of enterprise-ready identity— you'll wear the hat of a SaaS developer preparing your Todo application to support enterprise-level customers who want to use your Todo app within their organizations.
+Having an enterprise-ready SaaS application means your application supports authentication best practices, can scale across multiple customers and users, has automated means to re-create environments, and can securely add enhancements and value-adds your customers expect. Join this free virtual workshop series where we take your SaaS application on a journey of enterprise-ready identity — you'll wear the hat of a SaaS developer preparing your Todo application to support enterprise-level customers who want to use your Todo app within their organizations.
 
 In this post you'll install the necessary tools to build and run the Todo application locally.
 
@@ -21,12 +21,12 @@ The base application is a minimal "to-do list" built as a B2C application. You'l
 
 You can pick which workshop to participate in and the order in which you participate. Choose the workshops that best address your next most pressing need.
 
-|Posts in the enterprise-ready workshop series|
+|Posts in the on-demand workshop series|
 | --- |
-| 1. **How to Get Going with the Enterprise-Ready SaaS Apps Workshops** |
+| 1. **How to Get Going with the On-Demand SaaS Apps Workshops** |
 | 2. [Enterprise-Ready Workshop: Authenticate with OpenID Connect](/blog/2023/07/28/oidc_workshop) |
 | 3. [Enterprise-Ready Workshop: Manage Users with SCIM](/blog/2023/07/28/scim-workshop) |
-| 4. [Enterprise-Ready Workshop: Terraform](/blog/2023/07/28/terraform-workshop) |
+| 4. [Enterprise Maturity Workshop: Terraform](/blog/2023/07/28/terraform-workshop) |
 
 > We want to ensure you can follow the workshops and focus on understanding how to enhance the application for enterprise use cases, so don't use this base application as a template expecting a production-quality B2C or B2B application - it has some obvious intentional security shortcomings!
 

--- a/_source/_posts/2023-07-28-oidc_workshop.md
+++ b/_source/_posts/2023-07-28-oidc_workshop.md
@@ -17,12 +17,12 @@ This workshop is part of our Enterprise Readiness Workshop series.
 
 In this workshop, you will be wearing the hat of a SaaS developer who will up-level his/her app to allow users (from your big enterprise customers) to log on using their own company credentials without providing a password directly to your app. When any enterprise customer considers buying your software to enhance their employees' productivity, their IT and security teams want to make sure employees can access your app securely. As a developer, you'd prefer not to rebuild large portions of your authentication flow for every new customer. Fortunately, the OpenID Connect standard solves both of these problems! By adding OpenID Connect (OIDC) support to your app, you can meet the identity security needs of every enterprise organization that uses an OIDC-compatible identity provider. 
 
-|Posts in the enterprise-ready workshop series|
+|Posts in the on-demand workshop series|
 | --- |
-| 1. [How to Get Going with the Enterprise-Ready SaaS Apps Workshops](/blog/2023/07/27/enterprise-ready-getting-started) |
+| 1. [How to Get Going with the On-Demand SaaS Apps Workshops](/blog/2023/07/27/enterprise-ready-getting-started) |
 | 2. **Enterprise-Ready Workshop: Authenticate with OpenID Connect** |
 | 3. [Enterprise-Ready Workshop: Manage Users with SCIM](/blog/2023/07/28/scim-workshop) |
-| 4. [Enterprise-Ready Workshop: Terraform](/blog/2023/07/28/terraform-workshop) |
+| 4. [Enterprise Maturity Workshop: Terraform](/blog/2023/07/28/terraform-workshop) |
 
 Today, we'll walk through adding OIDC to our Todo sample application. 
 

--- a/_source/_posts/2023-07-28-scim-workshop.md
+++ b/_source/_posts/2023-07-28-scim-workshop.md
@@ -19,12 +19,12 @@ changelog:
 
 Hello SaaS developers! You sell your software to technologically mature enterprises, and they expect it to interface seamlessly with all their other tools. In our [Enterprise-Ready Workshop on OpenID Connect](/blog/2023-07-28-oidc_workshop), you learned how to solve part of this problem, by creating user accounts in your application for your customers' employees whenever they log in. 
 
-|Posts in the enterprise-ready workshop series|
+|Posts in the on-demand workshop series|
 | --- |
-| 1. [How to Get Going with the Enterprise-Ready SaaS Apps Workshops](/blog/2023/07/27/enterprise-ready-getting-started) |
+| 1. [How to Get Going with the On-Demand SaaS Apps Workshops](/blog/2023/07/27/enterprise-ready-getting-started) |
 | 2. [Enterprise-Ready Workshop: Authenticate with OpenID Connect](/blog/2023/07/28/oidc_workshop) |
 | 3. **Enterprise-Ready Workshop: Manage Users with SCIM** |
-| 4. [Enterprise-Ready Workshop: Terraform](/blog/2023/07/28/terraform-workshop) |
+| 4. [Enterprise Maturity Workshop: Terraform](/blog/2023/07/28/terraform-workshop) |
 
 But creating accounts when users log in is only one of your customers' many expectations! Your app is also expected to know about users who haven't logged in yet, and remove the accounts of employees who are removed from your customer's identity provider. 
 

--- a/_source/_posts/2023-07-28-terraform-workshop.md
+++ b/_source/_posts/2023-07-28-terraform-workshop.md
@@ -1,6 +1,6 @@
 ---
 layout: blog_post
-title: "Enterprise-Ready Workshop: Terraform"
+title: "Enterprise Maturity Workshop: Terraform"
 author: edunham 
 by: advocate
 communities: [devops,go]
@@ -14,12 +14,12 @@ type: awareness
 
 This workshop is part of our Enterprise-Ready Workshop series. Follow along to get familiar with managing identity as code using Okta's Terraform provider, so you can assist enterprise customers and simplify any identity setup steps that your product might require. In this workshop, you'll use Terraform to manage users and groups in an Okta Organization, while practicing beginner and intermediate Terraform skills.
 
-|Posts in the enterprise-ready workshop series|
+|Posts in the on-demand workshop series|
 | --- |
-| 1. [How to Get Going with the Enterprise-Ready SaaS Apps Workshops](/blog/2023/07/27/enterprise-ready-getting-started) |
+| 1. [How to Get Going with the On-Demand SaaS Apps Workshops](/blog/2023/07/27/enterprise-ready-getting-started) |
 | 2. [Enterprise-Ready Workshop: Authenticate with OpenID Connect](/blog/2023/07/28/oidc_workshop) |
 | 3. [Enterprise-Ready Workshop: Manage Users with SCIM](/blog/2023/07/28/scim-workshop) |
-| 4. **Enterprise-Ready Workshop: Terraform** |
+| 4. **Enterprise Maturity Workshop: Terraform** |
 
 The steps in this workshop are also demonstrated in the accompanying video, so that you can follow along in whatever medium is the best fit for your current learning needs.  
 


### PR DESCRIPTION
@palermo4 this changes overarching brand to "on-demand workshops" and differentiates readiness vs maturity within it. 

This does not add content explicitly differentiating readiness from maturity yet -- I've shared a g-doc with Michael drafting that post; I could either make it a thing in this PR or do that later.