### PR TITLE
Add trailing slash to blog link

### DIFF
--- a/_source/_includes/header.html
+++ b/_source/_includes/header.html
@@ -75,7 +75,7 @@
                         </ul>
                     </li>
                     <li class="menu-item {% if page.url contains '/blog/' %}active{% endif %}">
-                        <a href="/blog" class="nav-link">Blog</a>
+                        <a href="/blog/" class="nav-link">Blog</a>
                     </li>
                     <li class="menu-item {% if page.url contains '/pricing/' %}active{% endif %}">
                         <a href="{{ site.external_domain }}/pricing/" class="nav-link external-link">


### PR DESCRIPTION
The blog link in the OktaDev blog header doesn't work on prod only. I think it needs a trailing slash, so trying it out.
