### PR TITLE
update email alias

### DIFF
--- a/_source/_posts/2023-11-21-ai-identity-hackathon-winners.md
+++ b/_source/_posts/2023-11-21-ai-identity-hackathon-winners.md
@@ -120,4 +120,4 @@ We would like to also acknowledge and reward those for their community involveme
 We're thrilled with the results of this AI and Identity Hackathon experiment, delighted by the creative range of submission, and the diversity of the qualifying submissions. Our eligible submissions came from the United States and India, and overall participation was from dozens of countries. 
 We congratulate all the winners, supporters, and participants for making this an exciting hackathon!
 
-Have a story to share? Let us know with a comment below or reach out to us at wic-dev-advocacy@okta.com. For more interesting content, follow [@oktadev on Twitter](https://twitter.com/oktadev), connect with us [on LinkedIn](https://www.linkedin.com/company/oktadev), and subscribe to [our YouTube channel](https://www.youtube.com/oktadev).
+Have a story to share? Let us know with a comment below or reach out to us at `dev-advocacy` at okta dot com. For more interesting content, follow [@oktadev on Twitter](https://twitter.com/oktadev), connect with us [on LinkedIn](https://www.linkedin.com/company/oktadev), and subscribe to [our YouTube channel](https://www.youtube.com/oktadev).

--- a/_source/_posts/2024-05-01-okta-rsa.md
+++ b/_source/_posts/2024-05-01-okta-rsa.md
@@ -42,6 +42,6 @@ Universal Logout addresses this problem by offering administrators and their aut
 
 While the [Universal Logout](https://developer.okta.com/docs/guides/oin-universal-logout-overview/) feature provided by Okta has not yet been released, you can build the endpoint that IdPs such as Okta or threat detection tools can call to end a user session ASAP by following the instructions on this blog: [How to Instantly Sign a User Out across All Your Apps](/blog/2024/04/30/express-universal-logout).
 
-If you want to join a pilot program of integrators working with SSF and UL, contact us at `wic-dev-advocacy` at okta dot com.
+If you want to join a pilot program of integrators working with SSF and UL, contact us at `dev-advocacy` at okta dot com.
 
 If you are attending RSA, please stop by our booth and say hello! Whether you attend or not, the resources above are available for all to explore today!

--- a/_source/_posts/2024-05-03-shared-signals-framework-podcast.md
+++ b/_source/_posts/2024-05-03-shared-signals-framework-podcast.md
@@ -24,7 +24,7 @@ The Okta Workforce Identity Developer Podcast returns to discuss the OpenID Foun
 
 You can explore the Shared Signals Framework at [sharedsignals.guide](https://sharedsignals.guide/), and learn about Jamf's SSF integration [here](https://learn.jamf.com/en-US/bundle/jamf-security-cloud-setup-guide/page/Shared_Signals_Framework_SSF.html). 
 
-If you'd like to join a pilot program for using SSF to integrate with Okta, contact us at `wic-dev-advocacy` at okta dot com. If signals about security events were available, which could you send to other services? What signals would you want to receive in order to help your code detect threats quickly and accurately? Let us know in the comments below! 
+If you'd like to join a pilot program for using SSF to integrate with Okta, contact us at `dev-advocacy` at okta dot com. If signals about security events were available, which could you send to other services? What signals would you want to receive in order to help your code detect threats quickly and accurately? Let us know in the comments below! 
 
 Follow us on [Twitter](https://twitter.com/oktadev) and subscribe to our [YouTube](https://www.youtube.com/c/oktadev) channel. If you have any questions or you want to share what other topics you'd like to hear about on the podcast, please comment below!
 

--- a/_source/_posts/2024-09-26-oktane-saas-developers.md
+++ b/_source/_posts/2024-09-26-oktane-saas-developers.md
@@ -12,7 +12,7 @@ type: awareness
 
 We've been discussing and reflecting on the Future of Identity over the last couple of months. It's apparent to us that Identity is rapidly growing in its complexity. The surface area that our customers need to protect is growing, like a sunrise revealing a hidden terrain in the morning twilight. We realize that in a short time, the **growing demands of customers will start to influence the roadmaps of SaaS companies and their developers to keep pace with protecting their customers and differentiating their value in their respective markets.** The timing of this discussion couldn't be better! We would love to meet you, hear about your vision and challenges, and nerd out on Identity and Software Development. Join us at Caesars Forum in Las Vegas, NV, on October 15-17, 2024, for [Oktane](https://www.okta.com/oktane), the biggest identity event of the year, and learn how to propel your SaaS apps into the future by connecting with Okta!
 
-> If you are currently not attending Oktane (but would like to) and you build SaaS apps, please reach out to us at wic-dev-advocacy[at]okta.com to request information regarding how you can obtain a pass. Limited number of passes available so reach out soon!
+> If you are currently not attending Oktane (but would like to) and you build SaaS apps, please reach out to us at `dev-advocacy` at okta dot com to request information regarding how you can obtain a pass. Limited number of passes available so reach out soon!
 
 We planned fantastic events to help you take your SaaS apps to the next level by leveraging Okta's identity and user lifecycle platforms. Find us and let's chat at these activities: 
 
@@ -49,7 +49,7 @@ Labs are first-come-first-serve and have limited capacity. If there's a lab you'
 
 ## B2B SaaS builders happy hour
 
-Join us at a special event for those who build apps that connect with Okta for their customer base! This happy hour is where all the fun and connections happen. This is a private event exclusively for techy folk who build multi-tenant B2B SaaS applications and want to offer Okta Identity Provider connections as an option for their customers. Does this describe you and are you interested in attending this event? Please contact us at wic-dev-advocacy[at]okta.com to be added to our guest list. You must be an attendee at Oktane to attend this happy hour. 
+Join us at a special event for those who build apps that connect with Okta for their customer base! This happy hour is where all the fun and connections happen. This is a private event exclusively for techy folk who build multi-tenant B2B SaaS applications and want to offer Okta Identity Provider connections as an option for their customers. Does this describe you and are you interested in attending this event? Please contact us at `dev-advocacy` at okta dot com to be added to our guest list. You must be an attendee at Oktane to attend this happy hour. 
 
 ## Okta Workflows community meetup
 


### PR DESCRIPTION
Removes all instances of the string  `wic-dev-advocacy` from this repo. Replaces them with "`dev-advocacy` at okta dot com", since we were previously all over the place in how we had the alias spelled out or not. 