### PR TITLE
chore: Fix typos

### DIFF
--- a/2020-02-07-transactional-mfa.md
+++ b/2020-02-07-transactional-mfa.md
@@ -229,7 +229,7 @@ In the `app/index.html` which is auto-generated as a boilerplate during the crea
 
 **NOTE**: You'll need to replace the `baseUrl`, `clientId`, and `issuer` above with the values from your own Okta org.
 
-What's going on here is that the first time through, there will be a `stateToken` and the step-up MFA will be triggered. Once you've satisfied the factor requirement (such as acknowledging the push notification in Okta Verify), you're redirected back to this same page by virtue of the `redirectUri` defined above. The redirect includes the authorization code set by okta. The redirect is detected and the authorization code flow + pkce is completed by the widget:
+What's going on here is that the first time through, there will be a `stateToken` and the step-up MFA will be triggered. Once you've satisfied the factor requirement (such as acknowledging the push notification in Okta Verify), you're redirected back to this same page by virtue of the `redirectUri` defined above. The redirect includes the authorization code set by Okta. The redirect is detected and the authorization code flow + pkce is completed by the widget:
 
 ```javascript
 if (window.location.href.indexOf('#')) {

--- a/2025-02-26-okta-hosted-sign-in-widget.md
+++ b/2025-02-26-okta-hosted-sign-in-widget.md
@@ -812,7 +812,7 @@ The remaining task is to customize the default Content Security Policy (CSP) to 
 - ✅ Ensure the libraries you use for DOM manipulation are safe from XSS and appropriately sanitize inputs (if this applies to you). We have several blog posts on this topic if you search for [XSS](https://developer.okta.com/search/#q=xss&f:@commonoktasource=[Developer%20blog]) in our content collection. 
 - ✅ And lastly, it never hurts to get a security review when dealing with code affecting authentication.
 
-CSP is located under the **Settings** tab on the **Sign-in page** section, **Customizations** > **Brands** > **[your custom brand]** > **Pages** > **Sign-in page** > **Settings**. Un the **Content Security Policy** section, click on the **edit** button and add the following **Trusted external resources**:
+CSP is located under the **Settings** tab on the **Sign-in page** section, **Customizations** > **Brands** > **[your custom brand]** > **Pages** > **Sign-in page** > **Settings**. In the **Content Security Policy** section, click on the **edit** button and add the following **Trusted external resources**:
 - https://code.jquery.com
 - https://cdnjs.cloudflare.com
 - https://fonts.googleapis.com

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ What this command does is:
 - `-v $PWD:/app` - This mounts the current directory (the okta-blog source code repo) as `/app` in the Docker container's filesystem. This way, if you change articles or mess with the blog locally, your changes will be picked up by the blog software.
 - `-it` - These CLI options just map the Docker container to your current terminal so that when you CTRL+c to exit the blog the Docker container will be killed.
 - `okta-blog` - This is telling Docker to run the `okta-blog` image you created earlier using that `docker build` command. The `-t` option you specified earlier when running `docker build` assigned a name tag to the image so you could easily reference it.
-- `npm start` - This is the actual command you're telling Docker to run to launch the blog sofware. Docker will start the container up and then run this command inside the container to launch the Jekyll blog.
+- `npm start` - This is the actual command you're telling Docker to run to launch the blog software. Docker will start the container up and then run this command inside the container to launch the Jekyll blog.
 
 After that, all you have to do is open your browser and visit `http://localhost:4000` to visit the site!
 
@@ -206,7 +206,7 @@ To add a table of contents, use the following:
 {% include toc.md %}
 ```
 
-For AciiDoc, add the following just after the front matter:
+For AsciiDoc, add the following just after the front matter:
 
 ```
 :page-liquid:

--- a/_source/_posts/2025-02-28-podcast-season-2.md
+++ b/_source/_posts/2025-02-28-podcast-season-2.md
@@ -18,6 +18,6 @@ The Developer Podcast is back, focusing on all things integrator this season! In
 
 {% youtube BrbzKxnjRPo %} 
 
-You can also find this eposode in audio form [on Casted](https://listen.casted.us/public/49/Workforce-Identity-Developer-Podcast-4ce90a5f/d26b5401/share/0a9c3239) or your favorite source of podcasts. If it's missing from your preferred podcast platform, please let us know in the comments below. 
+You can also find this episode in audio form [on Casted](https://listen.casted.us/public/49/Workforce-Identity-Developer-Podcast-4ce90a5f/d26b5401/share/0a9c3239) or your favorite source of podcasts. If it's missing from your preferred podcast platform, please let us know in the comments below. 
 
 More episodes are coming soon, but if you can't wait, check out [last season](/blog/2023/06/08/identity-developer-podcast) for some still-relevant identity insights. 

--- a/_source/_posts/2025-06-16-sohail-pathan-intro.md
+++ b/_source/_posts/2025-06-16-sohail-pathan-intro.md
@@ -32,7 +32,7 @@ One fine afternoon, the founders approached me. They said – ***You have a gift
 
 The DevRel adventure deepened when I joined a deeptech startup that aimed to solve a big pain point: making it easier to run Android Studio on the cloud, which could help people with machines that have limited processing power (similar to Google's Firebase Studio today). As the Head of Developer Relations, my mission was clear – build and grow a community of Android developers who could test, give feedback, and shape our product.
 
-So, it was time to roll up my sleeves. I organized virtual and inperson meetups where developers could share their struggles and ideas. We even hosted hackathons, challenging participants to push the tool's limits and tell us what worked and what didn't. Week after week, I collected feedback, sifting through every comment and suggestion.
+So, it was time to roll up my sleeves. I organized virtual and in person meetups where developers could share their struggles and ideas. We even hosted hackathons, challenging participants to push the tool's limits and tell us what worked and what didn't. Week after week, I collected feedback, sifting through every comment and suggestion.
 
 {% img blog/sohail-pathan-intro/image3.jpeg alt:"Live session building the Disco Diwane app during an Android Study Jam in Nagpur" width:"782" %}{: .center-image }
 <cite style="display: block; text-align: center;">Image:Live session on building the Disco Diwane app during an Android Study Jam in Nagpur.</cite>


### PR DESCRIPTION
Editorial PR to fix some typos, primarily in the repo README.

This blog post has the following features:

- [ ] A GitHub Repository with a polished README
- [ ] A GitHub Repository under the github.com/oktadev account
- [ ] A title that's approved by Dev Advocacy
- [ ] A URL approved by Dev Advocacy
- [ ] The content has been run through Grammarly (https://www.grammarly.com/)
- [x] Rendered locally and confirmed that no Markdown typos exist
- [ ] Images are compressed appropriately
- [ ] Social image previews well on Twitter and LinkedIn
- [ ] Tech review request (developer advocate or domain expert)
- [ ] Review request for editorial/grammar/clarity (a member of the Dev Advocacy team)
